### PR TITLE
macOS tray app with stop functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -549,78 +549,37 @@ def main(
             + "</body></html>"
         )
 
-    # If running in normal CLI mode, start the HTTP server (used by tray as well)
-    uvicorn.run(app, host="0.0.0.0", port=7777)
+    # On macOS, run rumps on the main thread and uvicorn in the background.
+    # On other platforms, run uvicorn normally.
+    if sys.platform == "darwin":
+        def _start_server():
+            uvicorn.run(app, host="0.0.0.0", port=7777)
+        threading.Thread(target=_start_server, name="uvicorn-server", daemon=True).start()
+
+        try:
+            import rumps
+        except Exception:
+            # If rumps is unavailable, just keep the server running in background
+            # This avoids breaking non-macOS environments inadvertently.
+            threading.Event().wait()
+            return
+
+        def open_home(_=None):
+            webbrowser.open("http://localhost:7777/")
+
+        def quit_app(_=None):
+            sys.exit(0)
+
+        app_tray = rumps.App("Zotero MCP", callback=open_home)
+        app_tray.menu = [
+            rumps.MenuItem("Open Home", callback=open_home),
+            None,
+            rumps.MenuItem("Quit", callback=quit_app),
+        ]
+        app_tray.run()
+    else:
+        uvicorn.run(app, host="0.0.0.0", port=7777)
 
 
 if __name__ == "__main__":
-    # Support a macOS menu bar (tray) mode: `python main.py --tray`
-    # Default behavior still runs the CLI via arguably
-    if "--tray" in sys.argv or "--menubar" in sys.argv or "--menu-bar" in sys.argv:
-        # Start the server in a background thread
-        def start_server():
-            main()
-
-        server_thread = threading.Thread(target=start_server, name="uvicorn-server", daemon=True)
-        server_thread.start()
-
-        if sys.platform == "darwin":
-            # macOS: use rumps for true status bar app with click callback
-            try:
-                import rumps
-            except Exception:
-                # Fallback to pystray if rumps is missing
-                rumps = None
-
-            if rumps is not None:
-                def open_home(_=None):
-                    webbrowser.open("http://localhost:7777/")
-
-                def quit_app(_=None):
-                    sys.exit(0)
-
-                app = rumps.App("Zotero MCP", callback=open_home)
-                app.menu = [
-                    rumps.MenuItem("Open Home", callback=open_home),
-                    None,
-                    rumps.MenuItem("Quit", callback=quit_app),
-                ]
-                app.run()
-                sys.exit(0)
-
-        # Non-macOS or rumps unavailable: use pystray fallback
-        try:
-            import pystray
-            from PIL import Image, ImageDraw
-        except Exception:
-            print("Tray mode requires 'pystray' and 'Pillow' (or 'rumps' on macOS). Install them first.")
-            raise
-
-        def _create_icon(size: int = 16):
-            img = Image.new("RGBA", (size, size), (255, 255, 255, 0))
-            draw = ImageDraw.Draw(img)
-            r = size // 2 - 2
-            center = (size // 2, size // 2)
-            bbox = [center[0] - r, center[1] - r, center[0] + r, center[1] + r]
-            draw.ellipse(bbox, fill=(37, 99, 235, 255))
-            r2 = max(2, size // 6)
-            bbox2 = [center[0] - r2, center[1] - r2, center[0] + r2, center[1] + r2]
-            draw.ellipse(bbox2, fill=(255, 255, 255, 255))
-            return img
-
-        def on_click(icon, item=None):
-            webbrowser.open("http://localhost:7777/")
-
-        def on_quit(icon, item):
-            icon.visible = False
-            icon.stop()
-            sys.exit(0)
-
-        menu = pystray.Menu(
-            pystray.MenuItem("Open Home", on_click, default=True),
-            pystray.MenuItem("Quit", on_quit)
-        )
-        icon = pystray.Icon("Zotero MCP", _create_icon(18), "Zotero MCP", menu)
-        icon.run()
-    else:
-        arguably.run()
+    arguably.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,5 @@ dependencies = [
     "pymupdf>=1.26.3",
     "uvicorn>=0.35.0",
     "httpx>=0.28.1",
-    "pystray>=0.19.5",
-    "pillow>=10.4.0",
     "rumps>=0.4.0; sys_platform == 'darwin'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,7 @@ dependencies = [
     "pymupdf>=1.26.3",
     "uvicorn>=0.35.0",
     "httpx>=0.28.1",
+    "pystray>=0.19.5",
+    "pillow>=10.4.0",
+    "rumps>=0.4.0; sys_platform == 'darwin'",
 ]


### PR DESCRIPTION
Add macOS menu bar (tray) support with icon click to open the home page and a quit option.

---
<a href="https://cursor.com/background-agent?bcId=bc-de85792c-049b-4402-a68e-dad4520b3ad8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de85792c-049b-4402-a68e-dad4520b3ad8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

